### PR TITLE
Adição do PGAdmin como container para administração do PostgreSQL e a…

### DIFF
--- a/infrastructure/database/postgresql/docker-compose.yml
+++ b/infrastructure/database/postgresql/docker-compose.yml
@@ -1,14 +1,32 @@
-version: '2'
+version: '3'
 
 services:
-  postgresql:
+  postgresql-code-brother:
     image: 'bitnami/postgresql:11'
     ports:
       - '5432:5432'
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
-      - 'ALLOW_EMPTY_PASSWORD=yes'
+      POSTGRES_PASSWORD: "CodeBrother@2020"
+    networks:
+      - postgres-network
+
+  pgadmin-code-brother:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "codebrother@codebrother.com.br"
+      PGADMIN_DEFAULT_PASSWORD: "CodeBrother@2020"
+    ports:
+      - "16543:80"
+    depends_on:
+      - postgresql-code-brother
+    networks:
+      - postgres-network
+
+networks: 
+  postgres-network:
+    driver: bridge
 
 volumes:
   postgresql_data:


### PR DESCRIPTION
…justes nas configurações do PostgreSQL

#1 Versão atualizada para 3
#4 modificado nome da imagem
#11 Adicionado senha ao usuário postgres (default do postgresql)
#12 e #13 definição de uma rede para comunicação dos containers

#15 a #25 PGAdmin4 para facilitar a manuteção do banco sem um cliente local

#27 a #29 Detalhe do funcionamento da rede dos containers, por terem relação facilita a comunicação dos mesmos, em cada container a uma referencia linhas #13 e #25