### PR TITLE
Feature/messaging

### DIFF
--- a/backend/java/codebrothers.services.customer/pom.xml
+++ b/backend/java/codebrothers.services.customer/pom.xml
@@ -48,6 +48,15 @@
 	        <groupId>org.springframework.boot</groupId>
 	        <artifactId>spring-boot-starter-validation</artifactId>
     	</dependency>
+    	<dependency>
+			<groupId>org.springframework.amqp</groupId>
+			<artifactId>spring-rabbit-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/Application.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/Application.java
@@ -1,11 +1,60 @@
 package com.codebrothers.services.customer;
 
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 public class Application {
 
+	static final String topicExchangeName = "CustomerCreatedExchange";
+	static final String queueName = "CustomerCreated";
+	
+	/*
+	 * retorna um instacia da fila
+	 */
+	@Bean
+	Queue queue() {
+		return new Queue(queueName, false);		
+	}
+	
+	/*
+	 * Retorna uma instancia do topico ( exchange )
+	 */
+	@Bean
+	TopicExchange exchange() {
+		return new TopicExchange(topicExchangeName);
+	}
+	
+	/*
+	 *Cria a ligação entre o topico e a fila quando o assunto do do topico contiver codebrothers.customer. 
+	 */
+	/*@Bean
+	Binding binding(Queue queue, TopicExchange exchange) {
+		return BindingBuilder.bind(queue).to(exchange).with("codebrothers.customer.#");	
+	}*/
+	/*
+	@Bean
+	  SimpleMessageListenerContainer container(ConnectionFactory connectionFactory,
+	      MessageListenerAdapter listenerAdapter) {
+	    SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+	    container.setConnectionFactory(connectionFactory);
+	    container.setQueueNames(queueName);
+	    container.setMessageListener(listenerAdapter);
+	    return container;
+	  }
+*/
+	
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/controllers/CustomerController.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/controllers/CustomerController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.codebrothers.services.customer.entities.Customer;
+import com.codebrothers.services.customer.message.CustomerSender;
 import com.codebrothers.services.customer.services.CustomerService;
 
 @RestController
@@ -26,6 +27,9 @@ public class CustomerController {
    //  Injeção da classe que faz a parte de regras que forem necessarias
 	@Autowired
 	CustomerService customerservice;
+	
+	@Autowired
+	CustomerSender customerSender;
 
 	@GetMapping()
 	public ResponseEntity<List<Customer>> findAll() {
@@ -41,8 +45,10 @@ public class CustomerController {
 	public ResponseEntity<Customer> insert(@RequestBody @Valid Customer customer)
 	{
 		customer = customerservice.insert(customer);
+		//Posta o novo Customer Criado no messagebroker
+		customerSender.SendCreatedMessage(customer);
 		// adiciona ao header uma url com ID do registro criado
-		URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(customer.getId()).toUri();
+		URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(customer.getId()).toUri();		
 		return ResponseEntity.created(uri).body(customer);
 	}
 	

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/infrastructure/PropertiesLoader.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/infrastructure/PropertiesLoader.java
@@ -1,0 +1,30 @@
+package com.codebrothers.services.customer.infrastructure;
+
+
+public interface PropertiesLoader {
+	/*
+	 * FeatureToggle para definir o uso de comunicação via messageria
+	 */
+	public String getUseMessageBroker();
+	
+	/*
+	 * Propriedade indicando o nome da exchange para enviar a mensagem de customer criado
+	 */
+	public String getExchangeCustomerCreated();
+	
+	/*
+	 * Propriedade que indica o nome do assunto a ser enviado na exchange, permitindo filtros de
+	 * binding
+	 */
+	public String getExchangeSubjectCustomerCreated();
+	
+	/*
+	 * Propriedade indicando o nome da fila a ser criada
+	 */
+	public String getQueueCustomerCreated();
+	
+	/*
+	 * propriedade indicando a base do assunto para ser usado nos filtros da exchange
+	 */
+	public String getExchangeSubjectCustomerBase();
+}

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/infrastructure/PropertiesLoaderImpl.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/infrastructure/PropertiesLoaderImpl.java
@@ -1,0 +1,78 @@
+package com.codebrothers.services.customer.infrastructure;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.springframework.stereotype.Component;
+
+/*
+ * Classe responsável por expor as propriedades encontradas no arquivo de properties
+ */
+@Component
+public class PropertiesLoaderImpl implements PropertiesLoader {			
+
+	public PropertiesLoaderImpl() throws IOException {
+		this.properties = this.LoadProperties();
+	}
+	
+	public Properties getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Properties properties) {
+		this.properties = properties;
+	}
+
+	private Properties properties;
+	
+	/*
+	 * Carrega as propriedades do arquivo config.properties
+	 */
+	public Properties LoadProperties() throws IOException {
+		Properties prop = new Properties();
+		InputStream inputStream;
+		try {			
+			String propFileName = "config.properties";
+			
+			inputStream = getClass().getClassLoader().getResourceAsStream(propFileName);
+			
+			if(inputStream != null) {
+				prop.load(inputStream);				
+			}else {
+				throw new FileNotFoundException("o arquivo " + propFileName + " não foi encontrado");
+			}							
+		}
+		catch(Exception e) {
+			System.out.println("Ocorreu um erro ao tentar obter as propriedades >> " + e.getMessage());
+		}		
+		return prop;
+	}
+	
+	
+	/***        propriedades expostas no arquivo 		***/
+	
+	private String useMessageBroker;
+
+	public String getUseMessageBroker() {
+		return this.properties.getProperty("use.messagebroker");		
+	}
+	
+	public String getExchangeCustomerCreated() {
+		return this.properties.getProperty("customer.created.exchange");		
+	}
+	
+	public String getExchangeSubjectCustomerCreated() {
+		return this.properties.getProperty("customer.created.exchange.subject");		
+	}
+	
+	public String getQueueCustomerCreated() {
+		return this.properties.getProperty("customer.created.queue");		
+	}
+	
+	public String getExchangeSubjectCustomerBase() {
+		return this.properties.getProperty("customer.created.exchange.subject.base");		
+	}	
+
+}

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSender.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSender.java
@@ -1,0 +1,13 @@
+package com.codebrothers.services.customer.message;
+
+import com.codebrothers.services.customer.entities.Customer;
+/*
+ * Classe responsável pelo envio de informações do Customer ao MessageBroker
+ */
+public interface CustomerSender {
+	/*
+	 * Envia uma mensagem de cliente criado para o Broker, junto com o novo cliente
+	 */
+	Boolean SendCreatedMessage(Customer customer);
+
+}

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
@@ -1,0 +1,43 @@
+package com.codebrothers.services.customer.message;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import com.codebrothers.services.customer.entities.Customer;
+
+
+@Component
+public class CustomerSenderImpl implements CustomerSender{
+
+	static final String topicExchangeName = "CustomerCreatedExchange";
+	static final String queueName = "CustomerCreated";
+	private RabbitTemplate rabbitTemplate;	
+	
+	public CustomerSenderImpl(RabbitTemplate template) {
+		this.rabbitTemplate = template;
+	}
+	
+	
+	public Boolean SendCreatedMessage(Customer customer) {
+		
+		try {			
+			//utiliza o rabbitTemplate para envio da mensagem ao tópico ( exchange ) "codebrothers.customer.created"
+			rabbitTemplate.convertAndSend(topicExchangeName, "codebrothers.customer.created", customer);
+		}
+		catch(Exception e) {
+			return false;
+		}
+		
+		return true;
+	}
+	
+	
+}

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
@@ -1,36 +1,34 @@
 package com.codebrothers.services.customer.message;
 
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.core.TopicExchange;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
-import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.codebrothers.services.customer.entities.Customer;
+import com.codebrothers.services.customer.infrastructure.PropertiesLoader;
 
 
 @Component
 public class CustomerSenderImpl implements CustomerSender{
 
-	static final String topicExchangeName = "CustomerCreatedExchange";
-	static final String queueName = "CustomerCreated";
+	@Autowired
+	PropertiesLoader properties;
+		
 	private RabbitTemplate rabbitTemplate;	
 	
 	public CustomerSenderImpl(RabbitTemplate template) {
 		this.rabbitTemplate = template;
-	}
-	
-	
+	}	
+	/*
+	 * Envia uma mensagem notificando a criação do customer
+	 */
 	public Boolean SendCreatedMessage(Customer customer) {
 		
 		try {			
 			//utiliza o rabbitTemplate para envio da mensagem ao tópico ( exchange ) "codebrothers.customer.created"
-			rabbitTemplate.convertAndSend(topicExchangeName, "codebrothers.customer.created", customer);
+			rabbitTemplate.convertAndSend(properties.getExchangeCustomerCreated(),
+					properties.getExchangeSubjectCustomerCreated(),
+					customer);
 		}
 		catch(Exception e) {
 			return false;

--- a/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
+++ b/backend/java/codebrothers.services.customer/src/main/java/com/codebrothers/services/customer/message/CustomerSenderImpl.java
@@ -25,10 +25,12 @@ public class CustomerSenderImpl implements CustomerSender{
 	public Boolean SendCreatedMessage(Customer customer) {
 		
 		try {			
-			//utiliza o rabbitTemplate para envio da mensagem ao tópico ( exchange ) "codebrothers.customer.created"
-			rabbitTemplate.convertAndSend(properties.getExchangeCustomerCreated(),
-					properties.getExchangeSubjectCustomerCreated(),
-					customer);
+			if(properties.getUseMessageBroker().equals("s")) {
+				//utiliza o rabbitTemplate para envio da mensagem ao tópico ( exchange ) "codebrothers.customer.created"
+				rabbitTemplate.convertAndSend(properties.getExchangeCustomerCreated(),
+						properties.getExchangeSubjectCustomerCreated(),
+						customer);
+			}
 		}
 		catch(Exception e) {
 			return false;

--- a/backend/java/codebrothers.services.customer/src/main/resources/config.properties
+++ b/backend/java/codebrothers.services.customer/src/main/resources/config.properties
@@ -1,0 +1,7 @@
+#### Propriedades relacionadas ao message broker
+use.messagebroker=s
+
+customer.created.exchange.subject.base=codebrothers.customer
+customer.created.exchange.subject=codebrothers.customer.created
+customer.created.exchange=CustomerCreatedExchange
+customer.created.queue=CustomerCreated

--- a/backend/java/codebrothers.services.customer/src/test/java/com/codebrothers/services/customer/infrastructure/test/PropertiesLoaderTest.java
+++ b/backend/java/codebrothers.services.customer/src/test/java/com/codebrothers/services/customer/infrastructure/test/PropertiesLoaderTest.java
@@ -1,0 +1,59 @@
+package com.codebrothers.services.customer.infrastructure.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+
+import com.codebrothers.services.customer.infrastructure.PropertiesLoader;
+import com.codebrothers.services.customer.infrastructure.PropertiesLoaderImpl;
+
+
+@Component
+class PropertiesLoaderTest {
+
+	
+	PropertiesLoader pl;
+	
+	@BeforeEach
+	void setUp() throws Exception {
+		pl = new PropertiesLoaderImpl();
+	}
+	
+	@Test
+	void getUseMessageTest() {
+		String valor = pl.getUseMessageBroker();
+		assertNotNull(valor);
+		
+	}
+	
+	@Test
+	void getExchangeNameTest() {
+		String valor = pl.getExchangeCustomerCreated();
+		assertNotNull(valor);
+		
+	}
+	
+	@Test
+	void getExchangeSubjectNameTest() {
+		String valor = pl.getExchangeSubjectCustomerCreated();
+		assertNotNull(valor);
+		
+	}
+	
+	@Test
+	void getQueueNameTest() {
+		String valor = pl.getQueueCustomerCreated();
+		assertNotNull(valor);		
+	}
+	
+	@Test
+	void getExchangeSubjectBaseNameTest() {
+		String valor = pl.getExchangeSubjectCustomerBase();
+		assertNotNull(valor);
+		assertEquals(valor,  "codebrothers.customer");
+		
+	}
+
+}

--- a/backend/java/codebrothers.services.customer/src/test/java/com/codebrothers/services/customer/test/ApplicationTests.java
+++ b/backend/java/codebrothers.services.customer/src/test/java/com/codebrothers/services/customer/test/ApplicationTests.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ApplicationTests {
 
+	
     @Test
 	void contextLoads() {
 	}

--- a/infrastructure/messagebroker/rabbitmq/run.sh
+++ b/infrastructure/messagebroker/rabbitmq/run.sh
@@ -1,0 +1,1 @@
+docker-compose up -d


### PR DESCRIPTION
Foram implementadas funcionalidades para enviar uma mensagem ao messagebroker quando um post for feito com sucesso, enviando a exchange o customer recem criado.

As informações de configuração da parte da fila foram acrescentadas em um arquivo de config a parte. Talvez seja necessário alinharmos para colocar esses configs no mesmo formato definido pelo Marcos.

Somente o verbo POST está notificando o broker no momento, e a funcionalidade pode ser desativada através da chave use.messagebroker=s. Basta mudar o valor para n

Importante; As filas e exchanges estão sendo criadas no modo default, significando que ao fechar o container, o conteudo se perde.
Caso necessário, precisaremos configurar para que tudo seja criado em modo persistente.