### PR TITLE
Adicionado tratamento para exceção quando JWT for invalido e handle para custom exceptions!

### DIFF
--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/controllers/AuthController.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/controllers/AuthController.java
@@ -2,17 +2,14 @@ package com.codebrothers.services.auth.controllers;
 
 
 import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.codebrothers.services.auth.entities.User;
 import com.codebrothers.services.auth.services.AuthService;

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/controllers/UserController.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/controllers/UserController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.codebrothers.services.auth.entities.User;
-import com.codebrothers.services.auth.services.AuthService;
 import com.codebrothers.services.auth.services.UserService;
 
 import io.swagger.annotations.ApiOperation;

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/handles/AuthExceptionHandle.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/handles/AuthExceptionHandle.java
@@ -1,0 +1,67 @@
+package com.codebrothers.services.auth.handles;
+
+import java.time.Instant;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.codebrothers.services.auth.entities.StandardError;
+import com.codebrothers.services.auth.exceptions.DataBaseException;
+import com.codebrothers.services.auth.exceptions.ResourceForbiddenException;
+import com.codebrothers.services.auth.exceptions.ResourceNotFoundException;
+
+@ControllerAdvice
+public class AuthExceptionHandle  {
+    public Logger log  = LogManager.getLogger(this);
+    
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<StandardError> resourceNotFound(ResourceNotFoundException e, HttpServletRequest request) {
+        String error = "Resource not found!";
+        HttpStatus status = HttpStatus.NOT_FOUND;
+
+        log.error("Erro - {} - Stacktrace{}", e.getMessage(), e.getStackTrace());
+        
+        return ResponseEntity.status(status)
+                .body(new StandardError(Instant.now(), status.value(), error, e.getMessage(), request.getRequestURI()));
+    }
+
+    @ExceptionHandler(DataBaseException.class)
+    public ResponseEntity<StandardError> dataBase(DataBaseException e, HttpServletRequest request) {
+        String error = "Database error!";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        
+        log.error("Erro - {} - Stacktrace{}", e.getMessage(), e.getStackTrace());
+        
+        return ResponseEntity.status(status)
+                .body(new StandardError(Instant.now(), status.value(), error, e.getMessage(), request.getRequestURI()));
+    }
+
+    @ExceptionHandler(ResourceForbiddenException.class)
+    public ResponseEntity<StandardError> resourceForbiddenException(ResourceForbiddenException  e, HttpServletRequest request) {
+        String error = "Database error!";
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        
+        log.error("Erro - {} - Stacktrace{}", e.getMessage(), e.getStackTrace());
+        
+        return ResponseEntity.status(status)
+                .body(new StandardError(Instant.now(), status.value(), error, e.getMessage(), request.getRequestURI()));
+    }
+    
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<StandardError> dataBase(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String error = "Bad request!";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        log.error("Erro - {} - Stacktrace{}", e.getMessage(), e.getStackTrace());
+        
+        return ResponseEntity.status(status)
+                .body(new StandardError(Instant.now(), status.value(), error, e.getMessage(), request.getRequestURI()));
+    }
+}

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/interceptors/AuthInterceptor.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/interceptors/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package com.codebrothers.services.auth.interceptors;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -7,6 +8,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import com.codebrothers.services.auth.entities.StandardError;
+import com.codebrothers.services.auth.services.TokenService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,8 +24,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class AuthInterceptor extends HandlerInterceptorAdapter {
-    private Set<String> urlsByPass = new HashSet<>(); 
-    
+    private Set<String> urlsByPass = new HashSet<>();
+
+    @Autowired
+    TokenService jwtToken;
+
     public AuthInterceptor() {
         super();
         urlsByPass.add("/api/auth/v1/login");
@@ -30,17 +36,36 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        // Em caso de requerer algum tipo de auteticação vamos implementar nesse interceptor
-        if (request.getHeader("Authorization") == null && !urlsByPass.contains(request.getRequestURI())) {
-            response.setContentType("application/json;charset=UTF-8;");
-            response.getWriter().write(new StandardError(Instant.now(), HttpStatus.UNAUTHORIZED.value(), "Token inválido!","Não Autorizado!", request.getRequestURI()).toString());
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            
-            log.info("Request Method: {} - URI: {} -  Local Port: {} - Auth Type: {}",
-                    request.getMethod(), request.getRequestURI(), request.getLocalPort(), "Não autorizado");
-            
+        // Em caso de requerer algum tipo de auteticação vamos implementar nesse
+        // interceptor
+        
+        if(urlsByPass.contains(request.getRequestURI()))
+            return true;
+        
+        if (request.getHeader("Authorization") == null) {
+            responseInvalidJwt(request, response, HttpStatus.UNAUTHORIZED.value());
             return false;
         }
+
+        try {
+            if (!jwtToken.validateToken(request.getHeader("Authorization"))) {
+                responseInvalidJwt(request, response, HttpStatus.UNAUTHORIZED.value());
+                return false;
+            }
+        } catch (Exception e) {
+            responseInvalidJwt(request, response, HttpStatus.BAD_REQUEST.value());
+            log.error("AuthInterceptor - Error: {}", e.getMessage());
+            return false;
+        }
+
         return true;
+    }
+
+    private void responseInvalidJwt(HttpServletRequest request, HttpServletResponse response, int httpStatus) throws IOException {
+        response.setContentType("application/json;charset=UTF-8;");
+        response.getWriter().write(new StandardError(Instant.now(), httpStatus, "Token inválido!", "Token inválido!", request.getRequestURI()).toString());
+        response.setStatus(httpStatus);
+        
+        log.info("Request Method: {} - URI: {} -  Local Port: {} - HTTP Status: {}", request.getMethod(), request.getRequestURI(), request.getLocalPort(), "Não autorizado");
     }
 }

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/repositories/UserRepository.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/repositories/UserRepository.java
@@ -3,7 +3,6 @@ package com.codebrothers.services.auth.repositories;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import com.codebrothers.services.auth.entities.User;

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/services/TokenService.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/services/TokenService.java
@@ -20,12 +20,12 @@ import lombok.NoArgsConstructor;
 
 @Component
 @NoArgsConstructor
-public class TokenService implements Serializable{
+public class TokenService implements Serializable {
     private static final long serialVersionUID = -2550185165626007488L;
     private static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
     private SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-    private String subject =  "com.codebrothers.services.auth";
-    
+    private String subject = "com.codebrothers.services.auth";
+
     // generate token for user
     public String generateToken(User user) {
         Map<String, Object> claims = new HashMap<>();
@@ -42,24 +42,30 @@ public class TokenService implements Serializable{
         final Claims claims = getAllClaimsFromToken(token);
         return claimsResolver.apply(claims);
     }
-    
+
     // Validate token
     public Boolean validateToken(String token) {
-        token = token.replace("Bearer ", "");
-        return (!isTokenExpired(token));
+        return !isTokenExpired(token.replace("Bearer ", "")) ;
     }
+
     // for retrieveing any information from token we will need the secret key
-    // 1 -  Use the Jwts.parserBuilder() method to create a JwtParserBuilder instance.
-    // 2 - Specify the SecretKey or asymmetric PublicKey you want to use to verify the JWS signature.1
-    // 3 - Call the build() method on the JwtParserBuilder to return a thread-safe JwtParser.
-    // 4 - Finally, call the parseClaimsJws(String) method with your jws String, producing the original JWS.
-    // 5 - The entire call is wrapped in a try/catch block in case parsing or signature validation fails. We'll cover exceptions and causes for failure later.
+    // 1 - Use the Jwts.parserBuilder() method to create a JwtParserBuilder
+    // instance.
+    // 2 - Specify the SecretKey or asymmetric PublicKey you want to use to verify
+    // the JWS signature.1
+    // 3 - Call the build() method on the JwtParserBuilder to return a thread-safe
+    // JwtParser.
+    // 4 - Finally, call the parseClaimsJws(String) method with your jws String,
+    // producing the original JWS.
+    // 5 - The entire call is wrapped in a try/catch block in case parsing or
+    // signature validation fails. We'll cover exceptions and causes for failure
+    // later.
     private Claims getAllClaimsFromToken(String token) {
-        return Jwts.parserBuilder() // (1)
-                .setSigningKey(key) // (2)
-                .build() // (3)
-                .parseClaimsJws(token)
-                .getBody(); // (4)
+            return Jwts.parserBuilder() // (1)
+                    .setSigningKey(key) // (2)
+                    .build() // (3)
+                    .parseClaimsJws(token)// (4)
+                    .getBody(); // (5)
     }
 
     // Check if the token has expired
@@ -67,13 +73,10 @@ public class TokenService implements Serializable{
         final Date expiration = getExpirationDateFromToken(token);
         return expiration.before(new Date());
     }
-     
-    //while creating the token -
+
+    // while creating the token -
     private String doGenerateToken(Map<String, Object> claims) {
-        return Jwts.builder()
-                .setClaims(claims)
-                .setSubject(subject)
-                .setIssuedAt(new Date(System.currentTimeMillis()))
+        return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY * 1000)).signWith(key)
                 .compact();
     }

--- a/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/services/UserService.java
+++ b/backend/java/codebrothers.services.auth/src/main/java/com/codebrothers/services/auth/services/UserService.java
@@ -1,6 +1,5 @@
 package com.codebrothers.services.auth.services;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import javax.persistence.EntityNotFoundException;

--- a/backend/java/codebrothers.services.auth/src/test/java/com/codebrothers/services/auth/ApplicationTests.java
+++ b/backend/java/codebrothers.services.auth/src/test/java/com/codebrothers/services/auth/ApplicationTests.java
@@ -1,20 +1,15 @@
 package com.codebrothers.services.auth;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.validation.constraints.AssertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.codebrothers.services.auth.security.DataEncryptor;
 import com.codebrothers.services.auth.security.DataEncryptorImpl;
 
 import at.favre.lib.bytes.Bytes;
 import at.favre.lib.crypto.bcrypt.BCrypt;
-import at.favre.lib.crypto.bcrypt.BCryptFormatter;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 //@SpringBootTest
 class ApplicationTests {


### PR DESCRIPTION
Adicionado classe handle para devolver exceptions tratadas aos response padronizando o retorno.
Aplicado validação para JWT inválido.
- Requisições para URI diferente de "/api/auth/v1/login" que não tenham no header o item "Authorization" com um JWT válido, não terá o acesso válido. Validação aplicada no Interceptor.